### PR TITLE
Use Decimal instead of float on returned values

### DIFF
--- a/linode/api.py
+++ b/linode/api.py
@@ -30,6 +30,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
+from decimal import Decimal
 import logging
 import urllib
 import urllib2
@@ -244,7 +245,7 @@ class Api:
     logging.debug('Raw Response: '+response)
 
     try:
-      s = json.loads(response)
+      s = json.loads(response, parse_float=Decimal)
     except Exception, ex:
       print(response)
       raise ex
@@ -291,6 +292,7 @@ class Api:
           request[k] = params[k]
 
         result = func(self, request)
+
         if result is not None:
           request = result
 


### PR DESCRIPTION
This primarily affects avail.linodeplans' "PRICE" key, which
previously returned stuff like 29.949999999999999.  I don't know
if there are any other float values returned, but they haven't
been evaluated.

This may break downstream users who can't handle Decimal, i.e.
json.dumps.
