### PR TITLE
remove 'PaymentTerm' as a required parameter in linode_create.

### DIFF
--- a/linode/api.py
+++ b/linode/api.py
@@ -413,7 +413,7 @@ class Api:
     """
     pass
 
-  @__api_request(required=['DatacenterID', 'PlanID', 'PaymentTerm'],
+  @__api_request(required=['DatacenterID', 'PlanID'],
                  returns={u'LinodeID': 'New Linode ID'})
   def linode_create(self, request):
     """Create a new Linode.


### PR DESCRIPTION
PaymentTerm is no longer a required parameter in the API.
