### PR TITLE
Safe Pickling!

### DIFF
--- a/linode/api.py
+++ b/linode/api.py
@@ -91,8 +91,8 @@ except:
 
 class MissingRequiredArgument(Exception):
   """Raised when a required parameter is missing."""
-  
-  def __init__(self, value):
+
+  def __init__(self, value=str()):
     self.value = value
   def __str__(self):
     return repr(self.value)
@@ -123,8 +123,8 @@ class ApiError(Exception):
     40: Limit of Linodes added per hour reached
     41: Linode must have no disks before delete
   """
-  
-  def __init__(self, value):
+
+  def __init__(self, value=str()):
     self.value = value
   def __str__(self):
     return repr(self.value)
@@ -343,7 +343,7 @@ class Api:
       if returns and wrapper.__doc__:
         # we either have a list of dicts or a just plain dict
         if len(wrapper.__doc__.split('\n')) is 1:  # one-liners need whitespace
-          wrapper.__doc__ += '\n' 
+          wrapper.__doc__ += '\n'
         if isinstance(returns, list):
           width = max(len(q) for q in returns[0].keys())
           wrapper.__doc__ += '\n    Returns list of dictionaries:\n\t[{\n'
@@ -420,11 +420,11 @@ class Api:
     """Create a new Linode, then clone the specified LinodeID to the
     new Linode.  It is recommended that the source Linode be powered
     down during the clone.
-    
+
     This will create a billing event.
     """
     pass
-	
+
   @__api_request(required=['DatacenterID', 'PlanID', 'PaymentTerm'],
                  returns={u'LinodeID': 'New Linode ID'})
   def linode_create(self, request):
@@ -471,7 +471,7 @@ class Api:
                  returns={u'JobID': 'Job ID'})
   def linode_reboot(self, request):
     """Submit a reboot job for a Linode.
-    
+
     On job submission, returns the job ID.  Does not wait for job
     completion (see linode_job_list).
     """
@@ -535,7 +535,7 @@ class Api:
     linode_delete).
     """
     pass
-  
+
   @__api_request(required=['LinodeID'],
                  returns=[{u'CREATE_DT': u'YYYY-MM-DD hh:mm:ss.0',
                            u'DISKID': 'Disk ID',

--- a/linode/api.py
+++ b/linode/api.py
@@ -92,10 +92,12 @@ except:
 class MissingRequiredArgument(Exception):
   """Raised when a required parameter is missing."""
 
-  def __init__(self, value=str()):
+  def __init__(self, value):
     self.value = value
   def __str__(self):
     return repr(self.value)
+  def __reduce__(self):
+    return (self.__class__, (self.value, ))
 
 class ApiError(Exception):
   """Raised when a Linode API call returns an error.
@@ -124,10 +126,12 @@ class ApiError(Exception):
     41: Linode must have no disks before delete
   """
 
-  def __init__(self, value=str()):
+  def __init__(self, value):
     self.value = value
   def __str__(self):
     return repr(self.value)
+  def __reduce__(self):
+    return (self.__class__, (self.value, ))
 
 class ApiInfo:
   valid_commands = {}


### PR DESCRIPTION
### Reviewers (One of...)
- [ ] @tjfontaine  
- [ ] @rtucker 

### Summary
When leveraging the ```multiprocessing``` module, exceptions that are raised must be picklable. In order to be picklable, it seems that a class constructor must not have any undefined variables unless provided with a ```__reduce__``` method. There is a fairly detailed example on StackOverflow at the link below. I have also provided a sample that shows the before and after effect of these modifications. It looks like my ```.vimrc``` also sniped some whitespace from this script. Sorry about that! You can use the other link below to view my PR without whitespace changes.

http://stackoverflow.com/questions/8785899/hang-in-python-script-using-sqlalchemy-and-multiprocessing
https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-extension-types
https://github.com/tjfontaine/linode-python/pull/22/files?w=1

### Approach
We set up the ```__reduce__``` method.

### Risk
Significantly low! :+1: 

### Sample script

```
#!/usr/bin/env python

from random import randint
from linode.api import ApiError
from multiprocessing import Pool


def worker(d):
    print "Task initiated."
    num = randint(1, 100)
    if num < 30:
        raise ApiError("Test")
    return num


data = [{}] * 20
pool = Pool(processes=20, maxtasksperchild=1)
result = pool.map(worker, data)
print result
```

### Smoke Test Instructions

Prior to the modification, it is possible for processes to become stuck in a ```FUTEX_WAIT``` state:

#### Script output prior to api wrapper modification
```
# python mp.py
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 380, in _handle_results
    task = get()
TypeError: ('__init__() takes exactly 2 arguments (1 given)', <class 'linode.api.ApiError'>, ())

Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
```
#### Stuck system calls
```
root     31088  0.5  0.1 275272 13156 pts/0    Sl+  03:27   0:00  |       \_ python mp.py
root     31114  0.0  0.1 275272 10320 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31115  0.0  0.1 275272 10312 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31116  0.0  0.1 275272 10316 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31117  0.0  0.1 275272 10316 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31118  0.0  0.1 275272 10320 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31119  0.0  0.1 275272 10320 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31120  0.0  0.1 275272 10320 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31121  0.0  0.1 275272 10316 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31122  0.0  0.1 275272 10308 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31123  0.0  0.1 275272 10320 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31124  0.0  0.1 275272 10324 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31125  0.0  0.1 275272 10328 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31126  0.0  0.1 275272 10324 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31127  0.0  0.1 275272 10328 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31128  0.0  0.1 275272 10336 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31129  0.0  0.1 275272 10332 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31130  0.0  0.1 275272 10328 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31131  0.0  0.1 275272 10332 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31132  0.0  0.1 275272 10328 pts/0    S+   03:27   0:00  |           \_ python mp.py
root     31133  0.0  0.1 275272 10328 pts/0    S+   03:27   0:00  |           \_ python mp.py

root@hubby-v2-1:~# strace -p 31088
Process 31088 attached
futex(0x1b8d3f0, FUTEX_WAIT_PRIVATE, 0, NULL^CProcess 31088 detached
 <detached ...>
root@hubby-v2-1:~# strace -p 31114
Process 31114 attached
read(3, ^CProcess 31114 detached
 <detached ...>
root@hubby-v2-1:~# strace -p 31115
Process 31115 attached
futex(0x7fcd6e7b6000, FUTEX_WAIT, 0, NULL^CProcess 31115 detached
 <detached ...>
root@hubby-v2-1:~# strace -p 31116
Process 31116 attached
futex(0x7fcd6e7b6000, FUTEX_WAIT, 0, NULL^CProcess 31116 detached
 <detached ...>
root@hubby-v2-1:~#
```

#### Script output after modification
```
root@hubby-v2-1:~# python mp.py
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Traceback (most recent call last):
  File "mp.py", line 18, in <module>
Task initiated.
    result = pool.map(worker, data)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
Task initiated.
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
linode.api.ApiError: 'Test'
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
Task initiated.
root@hubby-v2-1:~#
```