### PR TITLE
Added PlanID fetched from Linode API List response.

### DIFF
--- a/linode/api.py
+++ b/linode/api.py
@@ -389,6 +389,7 @@ class Api:
                            u'LABEL': 'linode label',
                            u'LINODEID': 'Linode ID',
                            u'LPM_DISPLAYGROUP': 'group label',
+                           u'PLANID': 'plan id',
                            u'STATUS': 'Status flag',
                            u'TOTALHD': 'available disk (GB)',
                            u'TOTALRAM': 'available RAM (MB)',


### PR DESCRIPTION
I realized that the PLANID was not fetched from the Linode List response. I added it and used it internally. I figured someone else might find it useful.

Kindest regards,
Aleksandar