### PR TITLE
docs: fix simple typo, parms -> params

### DIFF
--- a/linode/VEpycurl.py
+++ b/linode/VEpycurl.py
@@ -74,7 +74,7 @@ class VEpycurl() :
             self.pco.setopt(pycurl.COOKIEFILE, cjf.name)
             self.pco.setopt(pycurl.COOKIEJAR,  cjf.name)
         if useSOCKS :
-            # if you wish to use SOCKS, it is configured through these parms
+            # if you wish to use SOCKS, it is configured through these params
             self.pco.setopt(pycurl.PROXY,     proxy)
             self.pco.setopt(pycurl.PROXYPORT, proxyPort)
             self.pco.setopt(pycurl.PROXYTYPE, proxyType)


### PR DESCRIPTION
There is a small typo in linode/VEpycurl.py.

Should read `params` rather than `parms`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md